### PR TITLE
Fix #5: Localised field values are not saved

### DIFF
--- a/cli/update-collection.php
+++ b/cli/update-collection.php
@@ -22,7 +22,7 @@ if (!$collection = $app->module('collections')->collection($name)) {
 
 $_id = $collection['_id'];
 
-$core_fields = ['_id', '_mby', '_by', '_modified', '_created'];
+$core_fields = ['_id', '_mby', '_by', '_modified', '_created', '_o', '_pid'];
 
 $collection_fields = array_map(function($item) {
   return $item['name'];


### PR DESCRIPTION
[Issue #5](https://github.com/pauloamgomes/CockpitCMS-Helpers/issues/5)

Keep service fields like ***_locale**, ***_slug** or ***_locale_slug** when collections and singletons are updated. Also when running the cli command `update-collection`.